### PR TITLE
Integer keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,7 @@ lmdb = "0.7"
 ordered-float = "0.5"
 uuid = "0.5"
 
+serde = "1.0"
+
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,0 +1,164 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::marker::{
+    PhantomData,
+};
+
+use bincode::{
+    Infinite,
+    serialize,
+};
+
+use lmdb::{
+    Database,
+    RoTransaction,
+};
+
+use serde::{
+    Serialize,
+};
+
+use error::{
+    DataError,
+    StoreError,
+};
+
+use value::{
+    Value,
+};
+
+use readwrite::{
+    Reader,
+    Store,
+    Writer,
+};
+
+use ::Kista;
+
+
+pub trait EncodableKey {
+    fn to_bytes(&self) -> Result<Vec<u8>, DataError>;
+}
+
+pub trait PrimitiveInt: EncodableKey {}
+
+impl PrimitiveInt for u32 {}
+
+impl<T> EncodableKey for T where T: Serialize {
+    fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
+        serialize(self, Infinite)         // TODO: limited key length.
+        .map_err(|e| e.into())
+    }
+}
+
+struct Key<K> {
+    bytes: Vec<u8>,
+    phantom: PhantomData<K>,
+}
+
+impl<K> AsRef<[u8]> for Key<K> where K: EncodableKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<K> Key<K> where K: EncodableKey {
+    fn new(k: K) -> Result<Key<K>, DataError> {
+        Ok(Key {
+            bytes: k.to_bytes()?,
+            phantom: PhantomData,
+        })
+    }
+}
+
+pub struct IntegerStore<K> where K: PrimitiveInt {
+    inner: Store<Key<K>>,
+}
+
+pub struct IntegerReader<'env, K> where K: PrimitiveInt {
+    inner: Reader<'env, Key<K>>,
+}
+
+impl<'env, K> IntegerReader<'env, K> where K: PrimitiveInt {
+    pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
+        self.inner.get(Key::new(k)?)
+    }
+
+    pub fn abort(self) {
+        self.inner.abort();
+    }
+}
+
+pub struct IntegerWriter<'env, K> where K: PrimitiveInt {
+    inner: Writer<'env, Key<K>>,
+}
+
+impl<'env, K> IntegerWriter<'env, K> where K: PrimitiveInt {
+    pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
+        self.inner.get(Key::new(k)?)
+    }
+
+    pub fn put<'s>(&'s mut self, k: K, v: &Value) -> Result<(), StoreError> {
+        self.inner.put(Key::new(k)?, v)
+    }
+
+    fn abort(self) {
+        self.inner.abort();
+    }
+}
+
+impl<K> IntegerStore<K> where K: PrimitiveInt {
+    pub fn new(db: Database) -> IntegerStore<K> {
+        IntegerStore {
+            inner: Store::new(db),
+        }
+    }
+
+    pub fn read<'env>(&self, env: &'env Kista) -> Result<IntegerReader<'env, K>, StoreError> {
+        Ok(IntegerReader {
+            inner: self.inner.read(env)?,
+        })
+    }
+
+    pub fn write<'env>(&mut self, env: &'env Kista) -> Result<IntegerWriter<'env, K>, StoreError> {
+        Ok(IntegerWriter {
+            inner: self.inner.write(env)?,
+        })
+    }
+
+    pub fn get<'env, 'tx>(&self, tx: &'tx RoTransaction<'env>, k: K) -> Result<Option<Value<'tx>>, StoreError> {
+        let key = Key::new(k)?;
+        self.inner.get(tx, key)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate tempdir;
+
+    use self::tempdir::TempDir;
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn test_integer_keys() {
+        let root = TempDir::new("test_integer_keys").expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Kista::new(root.path()).expect("new succeeded");
+        let mut s: IntegerStore<u32> = k.create_or_open_integer("s").expect("open");
+
+        let mut writer = s.write(&k).expect("writer");
+
+        writer.put(123, &Value::Str("hello!")).expect("write");
+        assert_eq!(writer.get(123).expect("read"), Some(Value::Str("hello!")));
+    }
+}


### PR DESCRIPTION
LMDB allows the use of fixed-width integer keys by passing `INTEGER_KEY` as a flag.

In C, this is a huge footgun:

- You can pass integers of the wrong size.
- You can pass integers to non-integer-key stores, and non-integers to integer-key stores.
- You can use signed or unsigned integers by accident.
- Presumably you can run into endianness or machine-size issues in portability.

Rust allows us to prevent all of these.

This PR uses bincode to encode passed integers, wrapping them in a `Key` struct that implements `AsRef<[u8]>` to pass through. `IntegerStore` is distinct from `Store` because I'd rather have something work than carefully craft more Rust!

Note that we can't do something like `Into<AsRef<[u8]>>` because encoding is failable.

We _could_ effectively implement `AsRef` for integers by using `transmute`, but AIUI that raises the possibility of the encoding changing between machines or, conceivably, versions of Rust.